### PR TITLE
Asynchronous User List Loading, Fixed Issues 2005, 2014, 2021

### DIFF
--- a/app/controllers/ExperimentController.php
+++ b/app/controllers/ExperimentController.php
@@ -323,8 +323,8 @@ class ExperimentController extends BaseController
      */
     public function sharedUsers()
     {
-        if (array_key_exists('projId', $_POST)) {
-            return Response::json(SharingUtilities::getProfilesForSharedUsers());
+        if (array_key_exists('resourceId', $_GET)) {
+            return Response::json(SharingUtilities::getProfilesForSharedUsers($_GET['resourceId'], ResourceType::EXPERIMENT));
         }
         else {
             return Response::json(array("error" => "Error: No project specified"));
@@ -333,8 +333,8 @@ class ExperimentController extends BaseController
 
     public function unsharedUsers()
     {
-        if (array_key_exists('projId', $_POST)) {
-            return Response::json(SharingUtilities::getProfilesForUnsharedUsers());
+        if (array_key_exists('resourceId', $_POST)) {
+            return Response::json(SharingUtilities::getProfilesForUnsharedUsers($_GET['resourceId'], ResourceType::EXPERIMENT));
         }
         else {
             return Response::json(array("error" => "Error: No project specified"));

--- a/app/controllers/ExperimentController.php
+++ b/app/controllers/ExperimentController.php
@@ -333,11 +333,11 @@ class ExperimentController extends BaseController
 
     public function unsharedUsers()
     {
-        if (array_key_exists('resourceId', $_POST)) {
+        if (array_key_exists('resourceId', $_GET)) {
             return Response::json(SharingUtilities::getProfilesForUnsharedUsers($_GET['resourceId'], ResourceType::EXPERIMENT));
         }
         else {
-            return Response::json(array("error" => "Error: No project specified"));
+            return Response::json(array("error" => "Error: No experiment specified"));
         }
     }
 }

--- a/app/controllers/ExperimentController.php
+++ b/app/controllers/ExperimentController.php
@@ -73,7 +73,7 @@ class ExperimentController extends BaseController
                 "allowedFileSize" => $allowedFileSize
             );
 
-            $users = SharingUtilities::getAllUserProfiles($_POST['project'], ResourceType::PROJECT);
+            $users = SharingUtilities::getProfilesForSharedUsers($_POST['project'], ResourceType::PROJECT);
 
             return View::make("experiment/create-complete", array("expInputs" => $experimentInputs, "users" => json_encode($users)));
         } else if (isset($_POST['save']) || isset($_POST['launch'])) {
@@ -90,7 +90,7 @@ class ExperimentController extends BaseController
                     <a href=' . URL::to('/') . '"/experiment/summary?expId=' . $expId . '">go directly</a> to experiment summary page.</p>');
 
             }*/
-            $users = SharingUtilities::getAllUserProfiles($expId, ResourceType::EXPERIMENT);
+            $users = SharingUtilities::getProfilesForSharedUsers($expId, ResourceType::EXPERIMENT);
             return Redirect::to('experiment/summary?expId=' . $expId);
         } else
             return Redirect::to("home")->with("message", "Something went wrong here. Please file a bug report using the link in the Help menu.");
@@ -237,7 +237,7 @@ class ExperimentController extends BaseController
             'advancedOptions' => Config::get('pga_config.airavata')["advanced-experiment-options"]
         );
 
-        $users = SharingUtilities::getAllUserProfiles($_GET['expId'], ResourceType::EXPERIMENT);
+        $users = SharingUtilities::getProfilesForSharedUsers($_GET['expId'], ResourceType::EXPERIMENT);
 
         return View::make("experiment/edit", array("expInputs" => $experimentInputs, "users" => json_encode($users)));
     }
@@ -312,6 +312,33 @@ class ExperimentController extends BaseController
             'expStates' => $experimentStates,
             'expContainer' => $expContainer
         ));
+    }
+
+    /**
+     * Generate JSON containing permissions information for this project.
+     *
+     * This function retrieves the user profile and permissions for every user
+     * other than the client that has access to the project. In the event that
+     * the project does not exist, return an error message.
+     */
+    public function sharedUsers()
+    {
+        if (array_key_exists('projId', $_POST)) {
+            return Response::json(SharingUtilities::getProfilesForSharedUsers());
+        }
+        else {
+            return Response::json(array("error" => "Error: No project specified"));
+        }
+    }
+
+    public function unsharedUsers()
+    {
+        if (array_key_exists('projId', $_POST)) {
+            return Response::json(SharingUtilities::getProfilesForUnsharedUsers());
+        }
+        else {
+            return Response::json(array("error" => "Error: No project specified"));
+        }
     }
 }
 

--- a/app/controllers/ProjectController.php
+++ b/app/controllers/ProjectController.php
@@ -55,7 +55,7 @@ class ProjectController extends BaseController
     public function editView()
     {
         if (Input::has("projId")) {
-            $users = SharingUtilities::getAllUserProfiles(Input::get('projId'), ResourceType::PROJECT);
+            $users = SharingUtilities::getProfilesForSharedUsers(Input::get('projId'), ResourceType::PROJECT);
 
             return View::make("project/edit",
                 array("projectId" => Input::get("projId"),
@@ -119,8 +119,8 @@ class ProjectController extends BaseController
      */
     public function sharedUsers()
     {
-        if (array_key_exists('expId', $_POST)) {
-            return Response::json(SharingUtilities::getProfilesForSharedUsers());
+        if (array_key_exists('resourceId', $_GET)) {
+            return Response::json(SharingUtilities::getProfilesForSharedUsers($_GET['resourceId'], ResourceType::PROJECT));
         }
         else {
             return Response::json(array("error" => "Error: No project specified"));
@@ -129,8 +129,8 @@ class ProjectController extends BaseController
 
     public function unsharedUsers()
     {
-        if (array_key_exists('expId', $_POST)) {
-            return Response::json(SharingUtilities::getProfilesForUnsharedUsers());
+        if (array_key_exists('resourceId', $_GET)) {
+            return Response::json(SharingUtilities::getProfilesForUnsharedUsers($_GET['resourceId'], ResourceType::PROJECT));
         }
         else {
             return Response::json(array("error" => "Error: No project specified"));

--- a/app/controllers/ProjectController.php
+++ b/app/controllers/ProjectController.php
@@ -25,7 +25,7 @@ class ProjectController extends BaseController
 
     public function createView()
     {
-        $users = SharingUtilities::getAllUserProfiles();
+        $users = array();
         //var_dump($users);exit;
         return View::make("project/create", array("users" => json_encode($users)));
     }
@@ -120,8 +120,7 @@ class ProjectController extends BaseController
      */
     public function sharedUsers()
     {
-        $response = array();
-        if (Input::has('projId')) {
+        if (array_key_exists('expId', $_POST)) {
             return Response::json(SharingUtilities::getProfilesForSharedUsers());
         }
         else {
@@ -131,8 +130,8 @@ class ProjectController extends BaseController
 
     public function unsharedUsers()
     {
-        if (Input::has('projId')) {
-            return Response::json(SharingUtilities::getProfilesForUnsharedUsers);
+        if (array_key_exists('expId', $_POST)) {
+            return Response::json(SharingUtilities::getProfilesForUnsharedUsers());
         }
         else {
             return Response::json(array("error" => "Error: No project specified"));

--- a/app/controllers/ProjectController.php
+++ b/app/controllers/ProjectController.php
@@ -25,8 +25,7 @@ class ProjectController extends BaseController
 
     public function createView()
     {
-        $users = array();
-        //var_dump($users);exit;
+        $users = SharingUtilities::getAllUserProfiles();
         return View::make("project/create", array("users" => json_encode($users)));
     }
 

--- a/app/libraries/ExperimentUtilities.php
+++ b/app/libraries/ExperimentUtilities.php
@@ -572,7 +572,12 @@ class ExperimentUtilities
                 '<p>AiravataSystemException: ' . $ase->getMessage() . '</p>');
         }
 
-        ExperimentUtilities::share_experiment($expId, json_decode($share));
+        $share = json_decode($share);
+        $share->{Session::get("username")} = new stdClass();
+        $share->{Session::get("username")}->read = true;
+        $share->{Session::get("username")}->write = true;
+
+        ExperimentUtilities::share_experiment($expId, $share);
     }
 
 

--- a/app/libraries/ExperimentUtilities.php
+++ b/app/libraries/ExperimentUtilities.php
@@ -634,10 +634,8 @@ class ExperimentUtilities
             Airavata::updateExperiment(Session::get('authz-token'), $cloneId, $experiment);
 
             $share = SharingUtilities::getAllUserPermissions($expId, ResourceType::EXPERIMENT);
-            $share->{Session::get('username')} = new stdClass();
-            $share->{Session::get('username')}->read = true;
-            $share->{Session::get('username')}->write = true;
-            ExperimentUtilities::share_experiment($cloneId, $share);
+            $share[Session::get('username')] = ["read" => true, "write" => true];
+            ExperimentUtilities::share_experiment($cloneId, json_decode(json_encode($share)));
 
             return $cloneId;
         } catch (InvalidRequestException $ire) {
@@ -1131,7 +1129,7 @@ class ExperimentUtilities
         $expContainer = array();
         $expNum = 0;
         foreach ($experiments as $experiment) {
-            if (SharingUtilities::userCanRead(Session::get('username'), $experiment, ResourceType::EXPERIMENT)) {
+            if (SharingUtilities::userCanRead(Session::get('username'), $experiment->experimentId, ResourceType::EXPERIMENT)) {
                 $expValue = ExperimentUtilities::get_experiment_values($experiment, true);
                 $expContainer[$expNum]['experiment'] = $experiment;
                 if ($expValue["experimentStatusString"] == "FAILED")

--- a/app/libraries/ExperimentUtilities.php
+++ b/app/libraries/ExperimentUtilities.php
@@ -634,10 +634,9 @@ class ExperimentUtilities
             Airavata::updateExperiment(Session::get('authz-token'), $cloneId, $experiment);
 
             $share = SharingUtilities::getAllUserPermissions($expId, ResourceType::EXPERIMENT);
-            $share[Session::get("username")] = array("read" => true, "write" => true);
-            foreach ($share as $uid => $perms) {
-                $share[$uid] = (object) $perms;
-            }
+            $share->{Session::get('username')} = new stdClass();
+            $share->{Session::get('username')}->read = true;
+            $share->{Session::get('username')}->write = true;
             ExperimentUtilities::share_experiment($cloneId, $share);
 
             return $cloneId;
@@ -1132,12 +1131,14 @@ class ExperimentUtilities
         $expContainer = array();
         $expNum = 0;
         foreach ($experiments as $experiment) {
-            $expValue = ExperimentUtilities::get_experiment_values($experiment, true);
-            $expContainer[$expNum]['experiment'] = $experiment;
-            if ($expValue["experimentStatusString"] == "FAILED")
-                $expValue["editable"] = false;
-            $expContainer[$expNum]['expValue'] = $expValue;
-            $expNum++;
+            if (SharingUtilities::userCanRead(Session::get('username'), $experiment, ResourceType::EXPERIMENT)) {
+                $expValue = ExperimentUtilities::get_experiment_values($experiment, true);
+                $expContainer[$expNum]['experiment'] = $experiment;
+                if ($expValue["experimentStatusString"] == "FAILED")
+                    $expValue["editable"] = false;
+                $expContainer[$expNum]['expValue'] = $expValue;
+                $expNum++;
+            }
         }
 
         return $expContainer;

--- a/app/libraries/ProjectUtilities.php
+++ b/app/libraries/ProjectUtilities.php
@@ -211,7 +211,12 @@ class ProjectUtilities
             CommonUtilities::print_error_message('AiravataSystemException!<br><br>' . $ase->getMessage());
         }
 
-        ProjectUtilities::share_project($projectId, json_decode($share));
+        $share = json_decode($share);
+        $share->{Session::get('username')} = new stdClass();
+        $share->{Session::get('username')}->read = true;
+        $share->{Session::get('username')}->write = true;
+
+        ProjectUtilities::share_project($projectId, $share);
     }
 
 

--- a/app/libraries/SharingUtilities.php
+++ b/app/libraries/SharingUtilities.php
@@ -25,12 +25,14 @@ class SharingUtilities {
      * @return True if the user has read permission, false otherwise.
      */
     public static function userCanRead($uid, $resourceId, $dataResourceType) {
-        if (WSIS::usernameExists($uid)) {
-            $read = GrouperUtilities::getAllAccessibleUsers($resourceId, $dataResourceType, ResourcePermissionType::READ);
-            return (array_key_exists($uid, $read) ? true : false);
-        }
-        else {
-            return false;
+        $read = GrouperUtilities::getAllAccessibleUsers($resourceId, $dataResourceType, ResourcePermissionType::READ);
+        foreach($read as $user) {
+            if (strcmp($uid, $user) === 0) {
+                return true;
+            }
+            else {
+                return false;
+            }
         }
     }
 

--- a/app/routes.php
+++ b/app/routes.php
@@ -71,6 +71,10 @@ Route::get("project/browse", "ProjectController@browseView");
 
 Route::post("project/browse", "ProjectController@browseView");
 
+Route::get("project/shared-users", "ProjectController@sharedUsers");
+
+Route::get("project/unshared-users", "ProjectController@unsharedUsers");
+
 /*
  * Experiment Routes
 */
@@ -96,6 +100,10 @@ Route::get("experiment/getQueueView", "ExperimentController@getQueueView");
 Route::get("experiment/browse", "ExperimentController@browseView");
 
 Route::post("experiment/browse", "ExperimentController@browseView");
+
+Route::get("experiment/shared-users", "ExperimentController@sharedUsers");
+
+Route::get("experiment/unshared-users", "ExperimentController@unsharedUsers");
 
 Route::get("download", function(){
     if(Input::has("path") && (0 == strpos(Input::get("path"), Session::get('username'))

--- a/app/views/experiment/create-complete.blade.php
+++ b/app/views/experiment/create-complete.blade.php
@@ -46,6 +46,7 @@
 @parent
 <script>
     var users = {{ $users }};
+    $('#experiment-share').data({url: "{{URL::to('/')}}/project/unshared-users", resourceId: "{{$expInputs['project']}}"})
 </script>
 {{ HTML::script('js/sharing/sharing_utils.js') }}
 {{ HTML::script('js/sharing/share.js') }}

--- a/app/views/experiment/create-complete.blade.php
+++ b/app/views/experiment/create-complete.blade.php
@@ -46,7 +46,7 @@
 @parent
 <script>
     var users = {{ $users }};
-    $('#experiment-share').data({url: "{{URL::to('/')}}/project/unshared-users", resourceId: "{{$expInputs['project']}}"})
+    $('#project-share').data({url: "{{URL::to('/')}}/project/unshared-users", resourceId: "{{$expInputs['project']}}"})
 </script>
 {{ HTML::script('js/sharing/sharing_utils.js') }}
 {{ HTML::script('js/sharing/share.js') }}

--- a/app/views/experiment/edit.blade.php
+++ b/app/views/experiment/edit.blade.php
@@ -54,7 +54,7 @@
 @parent
 <script>
     var users = {{ $users }};
-    $('#experiment-share').data({url: "{{URL::to('/')}}/experiment/unshared-users", resourceId: "{{Input::get('expId')}}"})
+    $('#project-share').data({url: "{{URL::to('/')}}/experiment/unshared-users", resourceId: "{{Input::get('expId')}}"})
 </script>
 {{ HTML::script('js/sharing/sharing_utils.js') }}
 {{ HTML::script('js/sharing/share.js') }}

--- a/app/views/experiment/edit.blade.php
+++ b/app/views/experiment/edit.blade.php
@@ -54,6 +54,7 @@
 @parent
 <script>
     var users = {{ $users }};
+    $('#experiment-share').data({url: "{{URL::to('/')}}/experiment/unshared-users", resourceId: "{{Input::get('expId')}}"})
 </script>
 {{ HTML::script('js/sharing/sharing_utils.js') }}
 {{ HTML::script('js/sharing/share.js') }}

--- a/app/views/project/edit.blade.php
+++ b/app/views/project/edit.blade.php
@@ -62,6 +62,7 @@
 @parent
 <script>
     var users = {{ $users }};
+    $('#project-share').data({url: "{{ URL::to('/') }}/project/unshared-users", resourceId: "{{ Input::get('projId') }}"})
 </script>
 {{ HTML::script('js/sharing/sharing_utils.js') }}
 {{ HTML::script('js/sharing/share.js') }}

--- a/app/views/project/summary.blade.php
+++ b/app/views/project/summary.blade.php
@@ -110,7 +110,7 @@
 {{ HTML::script('js/time-conversion.js')}}
 <script>
     var users = {{ $users }};
-    console.log(users);
+    //console.log(users);
 </script>
 {{ HTML::script('js/sharing/sharing_utils.js') }}
 {{ HTML::script('js/sharing/share.js') }}

--- a/public/js/sharing/share.js
+++ b/public/js/sharing/share.js
@@ -110,11 +110,11 @@ $(function() {
                     var user, $user, $users;
 
                     $users = $('#share-box-users');
-                    $users.empty().removeClass('text-align-center');
-                    console.log(data);
+                    $users.removeClass('text-align-center');
+                    $users.text('');
                     for (user in data) {
                         if (data.hasOwnProperty(user)) {
-                            $user = createThumbnail(user, data.firstname, data.lastname, data.email, access_enum.NONE, true);
+                            $user = createThumbnail(user, data[user].firstname, data[user].lastname, data[user].email, access_enum.NONE, true);
                             $user.find('.sharing-thumbnail-access').hide();
 
                             $user.addClass('user-thumbnail');

--- a/public/js/sharing/share.js
+++ b/public/js/sharing/share.js
@@ -29,7 +29,7 @@ $(function() {
                 var data = users[user];
                 var access = access_enum.NONE;
                 if (data.hasOwnProperty("access")) {
-                    console.log("Found access parameter");
+                    //console.log("Found access parameter");
                     if (data.access.write) {
                         access = access_enum.WRITE;
                     }
@@ -47,7 +47,7 @@ $(function() {
                     $users.append($user);
                 }
                 else {
-                    console.log("adding shared user");
+                    //console.log("adding shared user");
                     $user.addClass('share-box-share-item sharing-updated');
                     share_settings[user] = data.access;
                     $share.append($user);
@@ -96,9 +96,11 @@ $(function() {
         if ($('#share-box-users').find('.user-thumbnail').length === 0) {
             ajax_data = $(e.target).data();
 
+            $('#share-box-users').addClass('text-align-center').text('Loading user list');
+
             $.ajax({
                 url: ajax_data.url,
-                method: 'post',
+                method: 'get',
                 data: {resourceId: ajax_data.resourceId},
                 dataType: "json",
                 error: function(xhr, status, error) {
@@ -109,7 +111,7 @@ $(function() {
 
                     $users = $('#share-box-users');
                     $users.empty().removeClass('text-align-center');
-
+                    console.log(data);
                     for (user in data) {
                         if (data.hasOwnProperty(user)) {
                             $user = createThumbnail(user, data.firstname, data.lastname, data.email, access_enum.NONE, true);
@@ -124,10 +126,7 @@ $(function() {
             });
         }
 
-        $('#share-box-users').addClass('text-align-center').text('Loading user list');
-
         $share_list = $('#shared-users').children();
-
         if ($share_list.filter('.sharing-thumbnail').length > 0) {
             $share_list.sort(comparator);
             $share_list.each(function(index, element) {

--- a/public/js/sharing/share.js
+++ b/public/js/sharing/share.js
@@ -89,9 +89,41 @@ $(function() {
 
     // Create, populate, and show the share box
     $('body').on('click', 'button#project-share, button#experiment-share', function(e) {
-        var $share_list;
+        var $share_list, ajax_data;
         e.stopPropagation();
         e.preventDefault();
+
+        if ($('#share-box-users').find('.user-thumbnail').length === 0) {
+            ajax_data = $(e.target).data();
+
+            $.ajax({
+                url: url,
+                data: {},
+                dataType: "json",
+                error: function(xhr, status, error) {
+                    $('#shared-users').addClass('text-align-center').text("Unable to load users from Airavata server.");
+                },
+                success: function(data, status, xhr) {
+                    var user, $user, $users;
+
+                    $users = $('#share-box-users');
+                    $users.empty().removeClass('text-align-center');
+
+                    for (user in data) {
+                        if (data.hasOwnProperty(user)) {
+                            $user = createThumbnail(user, data.firstname, data.lastname, data.email, access_enum.NONE, true);
+                            $user.find('.sharing-thumbnail-access').hide();
+
+                            $user.addClass('user-thumbnail');
+                            $user.addClass('share-box-users-item');
+                            $users.append($user);
+                        }
+                    }
+                }
+            });
+        }
+
+        $('#share-box-users').addClass('text-align-center').text('Loading user list');
 
         $share_list = $('#shared-users').children();
 

--- a/public/js/sharing/share.js
+++ b/public/js/sharing/share.js
@@ -97,8 +97,9 @@ $(function() {
             ajax_data = $(e.target).data();
 
             $.ajax({
-                url: url,
-                data: {},
+                url: ajax_data.url,
+                method: 'post',
+                data: {resourceId: ajax_data.resourceId},
                 dataType: "json",
                 error: function(xhr, status, error) {
                     $('#shared-users').addClass('text-align-center').text("Unable to load users from Airavata server.");


### PR DESCRIPTION
Updates:
- Client-side sharing utilities now load user lists via AJAX to reduce loading time
- Routes added to ExperimentController and ProjectController that return a JSON list of users
- Experiment Browse page now only loads experiments that the user has Grouper permissions for
- Default Project owner now has full permissions for the Default Project