### PR TITLE
AIRAVATA-2216 Sharing button's type is button

### DIFF
--- a/app/views/partials/sharing-display-body.blade.php
+++ b/app/views/partials/sharing-display-body.blade.php
@@ -1,6 +1,6 @@
 @if($form)
 <label for="project-share">Sharing Settings</label><br />
-<button class="btn btn-default" name="project-share" id="project-share">Share With Other Users</button><br />
+<button type="button" class="btn btn-default" name="project-share" id="project-share">Share With Other Users</button><br />
 @else
 <h3>Sharing Details</h3>
 @endif


### PR DESCRIPTION
This fixes the problem where clicking on the sharing button could
inadvertently submit the form if the page is still loading.

@scnakandala can you review this when you get a chance?