### PR TITLE
AIRAVATA-2230 Auto load queue view when only 1 compute resource

### DIFF
--- a/app/views/experiment/create-complete.blade.php
+++ b/app/views/experiment/create-complete.blade.php
@@ -109,19 +109,22 @@
 
     //Selecting the first option as the default
     $( document ).ready(function() {
-        var crId = $("#compute-resource").val();
-        $(".loading-img ").removeClass("hide");
-        $.ajax({
-            url: '../experiment/getQueueView',
-            type: 'get',
-            data: {crId: crId},
-            success: function (data) {
-                $(".queue-view").html(data);
-                $(".loading-img ").addClass("hide");
-            },error : function(data){
-                $(".loading-img ").addClass("hide");
-            }
-        });
+        var $cr = $("#compute-resource");
+        var crId = $cr.val();
+        if ($cr.children("option").size() === 1 && crId !== "") {
+            $(".loading-img ").removeClass("hide");
+            $.ajax({
+                url: '../experiment/getQueueView',
+                type: 'get',
+                data: {crId: crId},
+                success: function (data) {
+                    $(".queue-view").html(data);
+                    $(".loading-img ").addClass("hide");
+                },error : function(data){
+                    $(".loading-img ").addClass("hide");
+                }
+            });
+        }
     });
 
     //Setting the file input view JS code


### PR DESCRIPTION
When there are multiple compute resources available the first option
has value of empty string. Loading the queue view for the compute
resource id of empty string throws an error server side.  This code
change prevents that error from happening.