### PR TITLE
AIRAVATA-2270 encode special characters in experiment id/name

### DIFF
--- a/app/controllers/ExperimentController.php
+++ b/app/controllers/ExperimentController.php
@@ -107,7 +107,7 @@ class ExperimentController extends BaseController
                     <a href=' . URL::to('/') . '"/experiment/summary?expId=' . $expId . '">go directly</a> to experiment summary page.</p>');
 
             }*/
-            return Redirect::to('experiment/summary?expId=' . $expId);
+            return Redirect::to('experiment/summary?expId=' . urlencode($expId));
         } else
             return Redirect::to("home")->with("message", "Something went wrong here. Please file a bug report using the link in the Help menu.");
     }
@@ -235,16 +235,16 @@ class ExperimentController extends BaseController
         }*/
         if (isset($_POST['launch'])) {
             ExperimentUtilities::launch_experiment($experiment->experimentId);
-            return Redirect::to('experiment/summary?expId=' . $experiment->experimentId);
+            return Redirect::to('experiment/summary?expId=' . urlencode($experiment->experimentId));
         } elseif (isset($_POST['cancel'])) {
             ExperimentUtilities::cancel_experiment($experiment->experimentId);
-            return Redirect::to('experiment/summary?expId=' . $experiment->experimentId);
+            return Redirect::to('experiment/summary?expId=' . urlencode($experiment->experimentId));
         } elseif (isset($_POST['update-sharing'])) {
             if(Config::get('pga_config.airavata')["data-sharing-enabled"]){
                 $share = $_POST['share-settings'];
                 ExperimentUtilities::update_experiment_sharing($experiment->experimentId, json_decode($share));
             }
-            return Redirect::to('experiment/summary?expId=' . $experiment->experimentId);
+            return Redirect::to('experiment/summary?expId=' . urlencode($experiment->experimentId));
         }
     }
 
@@ -322,7 +322,7 @@ class ExperimentController extends BaseController
                 ));
             }
             else {
-                Redirect::to("experiment/summary?expId=" . $experiment->experimentId)->with("error", "You do not have permission to edit this experiment");
+                Redirect::to("experiment/summary?expId=" . urlencode($experiment->experimentId))->with("error", "You do not have permission to edit this experiment");
             }
         }else {
             return View::make("experiment/no-sharing-edit", array("expInputs" => $experimentInputs));
@@ -333,9 +333,9 @@ class ExperimentController extends BaseController
     {
         try{
             $cloneId = ExperimentUtilities::clone_experiment(Input::get('expId'), Input::get('projectId'));
-            return Redirect::to('experiment/edit?expId=' . $cloneId . "&clonedExp=true");
+            return Redirect::to('experiment/edit?expId=' . urlencode($cloneId) . "&clonedExp=true");
         }catch (Exception $ex){
-            return Redirect::to("experiment/summary?expId=" . Input::get('expId'))
+            return Redirect::to("experiment/summary?expId=" . urlencode(Input::get('expId')))
                 ->with("cloning-error", "Failed to clone experiment: " . $ex->getMessage());
         }
     }
@@ -358,7 +358,7 @@ class ExperimentController extends BaseController
                         ExperimentUtilities::launch_experiment($experiment->experimentId);
                     }
 
-                    return Redirect::to('experiment/summary?expId=' . $experiment->experimentId);
+                    return Redirect::to('experiment/summary?expId=' . urlencode($experiment->experimentId));
                 } else
                     return View::make("home");
             }
@@ -374,7 +374,7 @@ class ExperimentController extends BaseController
                     ExperimentUtilities::launch_experiment($experiment->experimentId);
                 }
 
-                return Redirect::to('experiment/summary?expId=' . $experiment->experimentId);
+                return Redirect::to('experiment/summary?expId=' . urlencode($experiment->experimentId));
             } else
                 return View::make("home");
         }

--- a/app/routes.php
+++ b/app/routes.php
@@ -306,7 +306,7 @@ Route::get("admin/dashboard/experimentStatistics", "AdminController@experimentSt
 Route::get("admin/dashboard/resources", "AdminController@resourcesView");
 
 Route::get("admin/dashboard/experiment/summary", function () {
-    return Redirect::to("experiment/summary?expId=" . $_GET["expId"] . "&dashboard=true");
+    return Redirect::to("experiment/summary?expId=" . urlencode($_GET["expId"]) . "&dashboard=true");
 });
 
 Route::get("admin/dashboard/credential-store", "AdminController@credentialStoreView");

--- a/app/views/admin/experiment-statistics.blade.php
+++ b/app/views/admin/experiment-statistics.blade.php
@@ -208,15 +208,6 @@
         }
     }
 
-    $(".experiment-statistics").on("click", ".get-exp-stats", function(){
-        expId = $(this).data("expid");
-        $(".experimentId").val( expId);
-        $(".get-experiment").click();
-        $('html, body').animate({
-            scrollTop: $(".get-experiment").offset().top - 100
-        }, 1000);
-    });
-
     //element coming from experiment-info blade
     $(document).on("click", ".popover-taskinfo", function(){ 
         $(this).popover();

--- a/app/views/admin/manage-experiments.blade.php
+++ b/app/views/admin/manage-experiments.blade.php
@@ -442,18 +442,15 @@ to be uncommented when actually in use.
 
         var expId = $(".experimentId").val();
         var expHTMLId = util.sanitizeHTMLId(expId);
-        console.log("expHTMLId", expHTMLId);
         if( $("#" + expHTMLId).length <= 0){
             $(".loading-img").removeClass("hide");
             $.ajax({
                 url: 'experiment/summary?expId=' + encodeURIComponent(expId),
                 type: 'get',
                 success: function (data) {
-                    //$(".experiment-info").html(data);
                     $("#myTabs").append('<li role="presentation"><a href="#' + expHTMLId + '" aria-controls="' + expHTMLId + '" role="tab" data-toggle="tab"><span class="expid-label"></span><button type="button" style="margin-left:10px;" class="close pull-right close-tab" aria-label="Close"><span aria-hidden="true">&times;</span></button></a></li>');
                     // Set expId with .text() so it gets properly escaped
                     $('#myTabs a[href="#' + expHTMLId + '"] .expid-label').text(expId);
-                    // $(".tab-content").append('<div role="tabpanel" class="tab-pane" id="' + expHTMLId + '">' + data + '</div>');
                     $(".tab-content").append('<div role="tabpanel" class="tab-pane" id="' + expHTMLId + '"></div>');
                     $(".tab-content #" + expHTMLId).html(data);
                     $('#myTabs a[href="#' + expHTMLId + '"]').tab('show'); // Select tab by name

--- a/app/views/admin/manage-experiments.blade.php
+++ b/app/views/admin/manage-experiments.blade.php
@@ -406,6 +406,7 @@ to be uncommented when actually in use.
 {{ HTML::script('js/flot/flot-data.js')}}
 -->
 {{ HTML::script('js/time-conversion.js')}}
+{{ HTML::script('js/util.js')}}
 <script>
 
     //make first tab of accordion open by default.
@@ -440,16 +441,22 @@ to be uncommented when actually in use.
     $(".get-experiment").click(function () {
 
         var expId = $(".experimentId").val();
-        if( $("#" + expId).length <= 0){
+        var expHTMLId = util.sanitizeHTMLId(expId);
+        console.log("expHTMLId", expHTMLId);
+        if( $("#" + expHTMLId).length <= 0){
             $(".loading-img").removeClass("hide");
             $.ajax({
-                url: 'experiment/summary?expId=' + expId,
+                url: 'experiment/summary?expId=' + encodeURIComponent(expId),
                 type: 'get',
                 success: function (data) {
                     //$(".experiment-info").html(data);
-                    $("#myTabs").append('<li role="presentation"><a href="#' + expId + '" aria-controls="' + expId + '" role="tab" data-toggle="tab">' + expId + '<button type="button" style="margin-left:10px;" class="close pull-right close-tab" aria-label="Close"><span aria-hidden="true">&times;</span></button></a></li>');
-                    $(".tab-content").append('<div role="tabpanel" class="tab-pane" id="' + expId + '">' + data + '</div>');
-                    $('#myTabs a[href="#' + expId + '"]').tab('show') // Select tab by name
+                    $("#myTabs").append('<li role="presentation"><a href="#' + expHTMLId + '" aria-controls="' + expHTMLId + '" role="tab" data-toggle="tab"><span class="expid-label"></span><button type="button" style="margin-left:10px;" class="close pull-right close-tab" aria-label="Close"><span aria-hidden="true">&times;</span></button></a></li>');
+                    // Set expId with .text() so it gets properly escaped
+                    $('#myTabs a[href="#' + expHTMLId + '"] .expid-label').text(expId);
+                    // $(".tab-content").append('<div role="tabpanel" class="tab-pane" id="' + expHTMLId + '">' + data + '</div>');
+                    $(".tab-content").append('<div role="tabpanel" class="tab-pane" id="' + expHTMLId + '"></div>');
+                    $(".tab-content #" + expHTMLId).html(data);
+                    $('#myTabs a[href="#' + expHTMLId + '"]').tab('show'); // Select tab by name
 
                     //$('#myTabs a[href="#expsummary"]').tab('show') // Select tab by name
 
@@ -461,8 +468,17 @@ to be uncommented when actually in use.
             });
         } else {
             // Experiment data already loaded so just show it
-            $('#myTabs a[href="#' + expId + '"]').tab('show');
+            $('#myTabs a[href="#' + expHTMLId + '"]').tab('show');
         }
+    });
+
+    $(".experiment-statistics").on("click", ".get-exp-stats", function(){
+        var expId = $(this).data("expid");
+        $(".experimentId").val( expId);
+        $(".get-experiment").click();
+        $('html, body').animate({
+            scrollTop: $(".get-experiment").offset().top - 100
+        }, 1000);
     });
 
     $("body").on("click", ".close-tab", function(){

--- a/app/views/admin/manage-gateway.blade.php
+++ b/app/views/admin/manage-gateway.blade.php
@@ -623,7 +623,7 @@
 
     $(".update-gateway").click( function( ev){
         ev.preventDefault();
-         $(this).prepend( "<img class='loading-gif' src='<?php echo URL::to('/'); ?>/assets/ajax-loader.gif'/>");
+         $(this).prepend( "<img class='loading-gif' src='{{{ URL::to('/') }}}/assets/ajax-loader.gif'/>");
 
         $(".fail-alert").remove();
         $(".success-alert").remove();

--- a/app/views/experiment/create-complete.blade.php
+++ b/app/views/experiment/create-complete.blade.php
@@ -12,10 +12,10 @@
 
     <form action="{{URL::to('/')}}/experiment/create" method="POST" role="form" enctype="multipart/form-data">
 
-        <input type="hidden" name="experiment-name" value="{{$expInputs['experimentName']}}">
-        <input type="hidden" name="experiment-description" value="{{$expInputs['experimentDescription']}}">
-        <input type="hidden" name="project" value="{{$expInputs['project']}}">
-        <input type="hidden" name="application" value="{{$expInputs['application']}}">
+        <input type="hidden" name="experiment-name" value="{{{$expInputs['experimentName']}}}">
+        <input type="hidden" name="experiment-description" value="{{{$expInputs['experimentDescription']}}}">
+        <input type="hidden" name="project" value="{{{$expInputs['project']}}}">
+        <input type="hidden" name="application" value="{{{$expInputs['application']}}}">
 
         @include('partials/experiment-inputs', array("expInputs" => $expInputs, "queueDefaults" =>
         $expInputs['queueDefaults']) )

--- a/app/views/experiment/edit.blade.php
+++ b/app/views/experiment/edit.blade.php
@@ -21,7 +21,7 @@
         <h1>Edit Experiment</h1>
 
         <form action="{{URL::to('/')}}/experiment/edit" method="POST" role="form" enctype="multipart/form-data">
-            <input type="hidden" name="expId" value="<?php echo Input::get('expId'); ?>"/>
+            <input type="hidden" name="expId" value="{{{ Input::get('expId') }}}"/>
 
             @include('partials/experiment-inputs', array( "expInputs", $expInputs))
 
@@ -56,7 +56,7 @@
     var users = {{ $users }};
     var owner = {{ $owner }};
     var projectOwner = {{ $projectOwner }};
-    $('#entity-share').data({url: "{{URL::to('/')}}/experiment/unshared-users", resourceId: "{{Input::get('expId')}}"})
+    $('#entity-share').data({url: "{{URL::to('/')}}/experiment/unshared-users", resourceId: {{json_encode(Input::get('expId'))}} })
 </script>
 {{ HTML::script('js/sharing/sharing_utils.js') }}
 {{ HTML::script('js/sharing/share.js') }}

--- a/app/views/experiment/no-sharing-create-complete.blade.php
+++ b/app/views/experiment/no-sharing-create-complete.blade.php
@@ -12,10 +12,10 @@
 
     <form action="{{URL::to('/')}}/experiment/create" method="POST" role="form" enctype="multipart/form-data">
 
-        <input type="hidden" name="experiment-name" value="{{$expInputs['experimentName']}}">
-        <input type="hidden" name="experiment-description" value="{{$expInputs['experimentDescription']}}">
-        <input type="hidden" name="project" value="{{$expInputs['project']}}">
-        <input type="hidden" name="application" value="{{$expInputs['application']}}">
+        <input type="hidden" name="experiment-name" value="{{{$expInputs['experimentName']}}}">
+        <input type="hidden" name="experiment-description" value="{{{$expInputs['experimentDescription']}}}">
+        <input type="hidden" name="project" value="{{{$expInputs['project']}}}">
+        <input type="hidden" name="application" value="{{{$expInputs['application']}}}">
 
         @include('partials/experiment-inputs', array("expInputs" => $expInputs, "queueDefaults" =>
         $expInputs['queueDefaults']) )

--- a/app/views/experiment/no-sharing-edit.blade.php
+++ b/app/views/experiment/no-sharing-edit.blade.php
@@ -20,7 +20,7 @@
         <h1>Edit Experiment</h1>
 
         <form action="{{URL::to('/')}}/experiment/edit" method="POST" role="form" enctype="multipart/form-data">
-            <input type="hidden" name="expId" value="<?php echo Input::get('expId'); ?>"/>
+            <input type="hidden" name="expId" value="{{{ Input::get('expId') }}}"/>
 
             @include('partials/experiment-inputs', array( "expInputs", $expInputs))
 

--- a/app/views/experiment/summary.blade.php
+++ b/app/views/experiment/summary.blade.php
@@ -49,7 +49,7 @@
             $.ajax({
                 type: "GET",
                 url: "{{URL::to('/') }}/experiment/summary",
-                data: {expId: "{{ Input::get('expId') }}", isAutoRefresh : autoRefresh },
+                data: {expId: {{ json_encode(Input::get('expId')) }}, isAutoRefresh : autoRefresh },
                 success: function (data) {
 
                     // Don't refresh the page if a dialog is open
@@ -95,7 +95,7 @@
 
     $('#refresh-experiment').click(function() {
         console.log(autoRefresh);
-        window.location.replace("{{URL::to('/') }}/experiment/summary?" + "expId=" + "{{ Input::get('expId') }}"+"&"+ "isAutoRefresh=" + autoRefresh);
+        window.location.replace("{{URL::to('/') }}/experiment/summary?expId={{ urlencode(Input::get('expId')) }}&isAutoRefresh=" + autoRefresh);
     });
 
     $('.modal, #share-box').on('show', function (e) {

--- a/app/views/partials/experiment-container.blade.php
+++ b/app/views/partials/experiment-container.blade.php
@@ -25,12 +25,12 @@
                 <tr>
                     <!-- Experiment Name -->
                     <td>
-                        <a href="{{URL::to('/')}}/experiment/summary?expId={{$experiment['experiment']->experimentId}}" target="_blank">
-                        {{ $experiment['experiment']->name }}
+                        <a href="{{URL::to('/')}}/experiment/summary?expId={{urlencode($experiment['experiment']->experimentId)}}" target="_blank">
+                        {{{ $experiment['experiment']->name }}}
                         </a>
                         @if(Config::get('pga_config.airavata')["data-sharing-enabled"])
                             @if( $experiment['expValue']['editable'] and $can_write[$experiment['experiment']->experimentId] === true)
-                                <a href="{{URL::to('/')}}/experiment/edit?expId={{$experiment['experiment']->experimentId}}" title="Edit"><span class="glyphicon glyphicon-pencil"></span></a>
+                                <a href="{{URL::to('/')}}/experiment/edit?expId={{urlencode($experiment['experiment']->experimentId)}}" title="Edit"><span class="glyphicon glyphicon-pencil"></span></a>
                             @endif
                         @endif
                     </td>
@@ -51,13 +51,13 @@
                     <td class="time" unix-time="{{ $experiment['experiment']->creationTime / 1000 }}"></td>
 
                     <td>
-                        <a class="{{ ExperimentUtilities::get_status_color_class( $experiment['expValue']['experimentStatusString'] ) }}" href="{{URL::to('/')}}/experiment/summary?expId={{$experiment['experiment']->experimentId}}" target="_blank">
+                        <a class="{{ ExperimentUtilities::get_status_color_class( $experiment['expValue']['experimentStatusString'] ) }}" href="{{URL::to('/')}}/experiment/summary?expId={{urlencode($experiment['experiment']->experimentId)}}" target="_blank">
                             {{$experiment['expValue']['experimentStatusString'] }}
                         </a>
                     </td>
                     @if( isset( $dashboard))
                     <td class="text-center">
-                        <a class="get-exp-stats" data-expid="{{$experiment['experiment']->experimentId}}" style="cursor: pointer;">
+                        <a class="get-exp-stats" data-expid="{{{$experiment['experiment']->experimentId}}}" style="cursor: pointer;">
                         <span class="glyphicon glyphicon-stats"></span>
                         </a>
                     </td>

--- a/app/views/partials/experiment-info.blade.php
+++ b/app/views/partials/experiment-info.blade.php
@@ -46,15 +46,15 @@
     <table class="table table-bordered">
         <tr>
             <td><strong>Experiment ID</strong></td>
-            <td><?php echo $experiment->experimentId; ?></td>
+            <td>{{{ $experiment->experimentId }}}</td>
         </tr>
         <tr>
             <td><strong>Name</strong></td>
-            <td><?php echo $experiment->experimentName; ?></td>
+            <td>{{{ $experiment->experimentName }}}</td>
         </tr>
         <tr>
             <td><strong>Description</strong></td>
-            <td><?php echo $experiment->description; ?></td>
+            <td>{{{ $experiment->description }}}</td>
         </tr>
         <tr>
             <td><strong>Project</strong></td>
@@ -66,7 +66,7 @@
         </tr>
         <tr>
             <td><strong>Owner</strong></td>
-            <td><?php echo $experiment->userName; ?></td>
+            <td>{{{ $experiment->userName }}}</td>
         </tr>
         <tr>
             <td><strong>Application</strong></td>
@@ -90,7 +90,7 @@
         @endif
         <tr>
             <td><strong>Experiment Status</strong></td>
-            <td class="exp-status"><?php echo $expVal["experimentStatusString"]; ?></td>
+            <td class="exp-status">{{{ $expVal["experimentStatusString"] }}}</td>
         </tr>
 
         @foreach( $expVal["jobDetails"] as $index => $jobDetail)
@@ -166,7 +166,7 @@
         </tr>
         <tr>
             <td><strong>Enable Auto Schedule</strong></td>
-            <td><?php echo $experiment->userConfigurationData->airavataAutoSchedule==1?"true":"false"; ?></td>
+            <td>{{{ $experiment->userConfigurationData->airavataAutoSchedule==1?"true":"false" }}}</td>
         </tr>
         <tr>
             <td><strong>Wall Time</strong></td>
@@ -255,8 +255,8 @@
                 <span class="glyphicon glyphicon-stop"></span>
                 Cancel
             </button>
-            <input type="hidden" name="expId" value="{{ Input::get('expId') }}"/>
-            <a href="{{URL::to('/') }}/experiment/edit?expId={{ $experiment->experimentId }}&savedExp=true"
+            <input type="hidden" name="expId" value="{{{ Input::get('expId') }}}"/>
+            <a href="{{URL::to('/') }}/experiment/edit?expId={{ urlencode($experiment->experimentId) }}&savedExp=true"
                class="btn btn-primary"
                role="button"
                title="Edit experiment" <?php if (!$expVal["editable"]) echo 'style="display: none"' ?>>
@@ -304,7 +304,7 @@
             </div>
             <div class="modal-body">
                 <form class="form-inline" action="{{ URL::to('/') }}/experiment/clone" method="post">
-                    <input type="hidden" name="expId" value="{{ Input::get('expId') }}"/>
+                    <input type="hidden" name="expId" value="{{{ Input::get('expId') }}}"/>
                     <div class="form-group">
                         <label for="projectId">Project</label>
                         <select class="form-control" name="projectId" required>
@@ -342,7 +342,7 @@
 <div class="tree">
     <ul>
         <li>
-            <span><i class="icon-calendar"></i>{{ $detailedExperiment->experimentName }}</span>
+            <span><i class="icon-calendar"></i>{{{ $detailedExperiment->experimentName }}}</span>
             <ul>
                 @foreach( $detailedExperiment->processes as $index => $process)
                 <li>
@@ -423,9 +423,9 @@
         var users = {{ $users }};
         var owner = {{ $owner }};
         var projectOwner = {{ $projectOwner }};
-        $('#update-sharing').data({url: "{{URL::to('/')}}/experiment/unshared-users", resourceId: "{{Input::get('expId')}}"})
+        $('#update-sharing').data({url: "{{URL::to('/')}}/experiment/unshared-users", resourceId: {{json_encode(Input::get('expId'))}} });
         @if($updateSharingViaAjax)
-        $('#share-box-button').data({ajaxUpdateUrl: "{{URL::to('/')}}/experiment/update-sharing?expId={{Input::get('expId')}}", resourceId: "{{Input::get('expId')}}"})
+        $('#share-box-button').data({ajaxUpdateUrl: "{{URL::to('/')}}/experiment/update-sharing?expId={{urlencode(Input::get('expId'))}}", resourceId: {{json_encode(Input::get('expId'))}} });
         @endif
     </script>
     {{ HTML::script('js/sharing/sharing_utils.js') }}

--- a/app/views/partials/experiment-inputs.blade.php
+++ b/app/views/partials/experiment-inputs.blade.php
@@ -2,15 +2,15 @@
     <label for="experiment-name" class="control-label">Experiment Name</label>
     <input type="text" class="form-control" name="experiment-name" id="experiment-name"
            placeholder="Enter experiment name" autofocus required="required" maxlength="50" {{ $expInputs['disabled'] }}
-    value="{{
-    $expInputs['experimentName'] }}">
+    value="{{{
+    $expInputs['experimentName'] }}}">
 </div>
 <div class="form-group">
     <label for="experiment-description">Experiment Description</label>
     <textarea class="form-control" name="experiment-description" id="experiment-description"
               placeholder="Optional: Enter a short description of the experiment" maxlength="200" {{
-    $expInputs['disabled'] }}>{{
-    $expInputs['experimentDescription'] }}</textarea>
+    $expInputs['disabled'] }}>{{{
+    $expInputs['experimentDescription'] }}}</textarea>
 </div>
 <div class="form-group required">
     <label for="project" class="control-label">Project</label>

--- a/app/views/project/browse.blade.php
+++ b/app/views/project/browse.blade.php
@@ -120,10 +120,10 @@
                             <?php echo $project->creationTime / 1000 ?>">
                     </td>
                     <td>
-                        <a href="{{URL::to('/')}}/project/summary?projId=<?php echo $project->projectID; ?>">
+                        <a href="{{URL::to('/')}}/project/summary?projId={{ urlencode($project->projectID) }}">
                             <span class="glyphicon glyphicon-list"></span>
                         </a>
-                        <a href="{{URL::to('/')}}/project/summary?projId=<?php echo $project->projectID; ?>"> View</a>
+                        <a href="{{URL::to('/')}}/project/summary?projId={{{ $project->projectID }}}"> View</a>
                     </td>
                 </tr>
             <?php

--- a/app/views/project/no-sharing-browse.blade.php
+++ b/app/views/project/no-sharing-browse.blade.php
@@ -106,8 +106,8 @@
                 ?>
                 <tr>
                     <td>
-                        <?php echo $project->name; ?>
-                        <a href="{{URL::to('/')}}/project/edit?projId=<?php echo $project->projectID; ?>" title="Edit">
+                        {{{ $project->name }}}
+                        <a href="{{URL::to('/')}}/project/edit?projId={{ urlencode($project->projectID) }}" title="Edit">
                             <span class="glyphicon glyphicon-pencil"></span>
                         </a>
                     </td>
@@ -118,10 +118,10 @@
                             <?php echo $project->creationTime / 1000 ?>">
                     </td>
                     <td>
-                        <a href="{{URL::to('/')}}/project/summary?projId=<?php echo $project->projectID; ?>">
+                        <a href="{{URL::to('/')}}/project/summary?projId={{ urlencode($project->projectID) }}">
                             <span class="glyphicon glyphicon-list"></span>
                         </a>
-                        <a href="{{URL::to('/')}}/project/summary?projId=<?php echo $project->projectID; ?>"> View</a>
+                        <a href="{{URL::to('/')}}/project/summary?projId={{ urlencode($project->projectID) }}"> View</a>
                     </td>
                 </tr>
             <?php

--- a/app/views/project/no-sharing-summary.blade.php
+++ b/app/views/project/no-sharing-summary.blade.php
@@ -58,7 +58,7 @@
                 <tr>
                     <td>
                         <a href="{{URL::to('/')}}/experiment/summary?expId={{urlencode($experiment->experimentId)}}">
-                        {{ $experiment->experimentName }}
+                        {{{ $experiment->experimentName }}}
                         </a>
                         @if( $expValues['editable'] and $experiment_can_write[$experiment->experimentId] === true)
                             <a href="{{URL::to('/')}}/experiment/edit?expId={{urlencode($experiment->experimentId)}}" title="Edit"><span class="glyphicon glyphicon-pencil"></span></a>

--- a/app/views/project/no-sharing-summary.blade.php
+++ b/app/views/project/no-sharing-summary.blade.php
@@ -57,11 +57,11 @@
 
                 <tr>
                     <td>
-                        <a href="{{URL::to('/')}}/experiment/summary?expId={{$experiment->experimentId}}">
+                        <a href="{{URL::to('/')}}/experiment/summary?expId={{urlencode($experiment->experimentId)}}">
                         {{ $experiment->experimentName }}
                         </a>
                         @if( $expValues['editable'] and $experiment_can_write[$experiment->experimentId] === true)
-                            <a href="{{URL::to('/')}}/experiment/edit?expId={{$experiment->experimentId}}" title="Edit"><span class="glyphicon glyphicon-pencil"></span></a>
+                            <a href="{{URL::to('/')}}/experiment/edit?expId={{urlencode($experiment->experimentId)}}" title="Edit"><span class="glyphicon glyphicon-pencil"></span></a>
                         @endif
                     </td>
                     <td>{{ $experiment->userName }}</td>

--- a/app/views/project/summary.blade.php
+++ b/app/views/project/summary.blade.php
@@ -61,7 +61,7 @@
                 <tr>
                     <td>
                         <a href="{{URL::to('/')}}/experiment/summary?expId={{urlencode($experiment->experimentId)}}">
-                        {{ $experiment->experimentName }}
+                        {{{ $experiment->experimentName }}}
                         </a>
                         @if( $expValues['editable'] and $experiment_can_write[$experiment->experimentId] === true)
                             <a href="{{URL::to('/')}}/experiment/edit?expId={{urlencode($experiment->experimentId)}}" title="Edit"><span class="glyphicon glyphicon-pencil"></span></a>

--- a/app/views/project/summary.blade.php
+++ b/app/views/project/summary.blade.php
@@ -60,11 +60,11 @@
 
                 <tr>
                     <td>
-                        <a href="{{URL::to('/')}}/experiment/summary?expId={{$experiment->experimentId}}">
+                        <a href="{{URL::to('/')}}/experiment/summary?expId={{urlencode($experiment->experimentId)}}">
                         {{ $experiment->experimentName }}
                         </a>
                         @if( $expValues['editable'] and $experiment_can_write[$experiment->experimentId] === true)
-                            <a href="{{URL::to('/')}}/experiment/edit?expId={{$experiment->experimentId}}" title="Edit"><span class="glyphicon glyphicon-pencil"></span></a>
+                            <a href="{{URL::to('/')}}/experiment/edit?expId={{urlencode($experiment->experimentId)}}" title="Edit"><span class="glyphicon glyphicon-pencil"></span></a>
                         @endif
                     </td>
                     <td>{{ $experiment->userName }}</td>

--- a/public/js/util.js
+++ b/public/js/util.js
@@ -1,0 +1,12 @@
+
+var util = (function(){
+    "use strict";
+    
+    return {
+        sanitizeHTMLId: function(id) {
+            // Replace anything that isn't an HTML safe id character with underscore
+            // Here safe means allowable by HTML5 and also safe to use in a jQuery selector
+            return id.replace(/[^a-zA-Z0-9_-]/g, "_");
+        }
+    };
+})();


### PR DESCRIPTION
This fixes several problems related to special characters in the experiment id/name. Initially this started as an issue to fix loading experiment details in the Experiment Statistics view in the Admin Dashboard, but I went ahead and fixed the other places where encoding was missing.