### PR TITLE
[AIRAVATA-2475] Enabling updates to the Gateway while Admin approves it

### DIFF
--- a/app/libraries/AdminUtilities.php
+++ b/app/libraries/AdminUtilities.php
@@ -144,6 +144,10 @@ class AdminUtilities
         }
         if( isset($gatewayData["createTenant"])) {
             $gatewayData["declinedReason"] = " ";
+            if ($gateway->identityServerPasswordToken == null)
+            {
+                Session::put("errorMessages", "Error: Please ask the Gateway Provider to submit a password.");
+            }
             foreach ($gatewayData as $data) {
                 if ($data == null) {
                     return -1;
@@ -153,6 +157,13 @@ class AdminUtilities
             $gateway->gatewayApprovalStatus = GatewayApprovalStatus::CREATED;
         }
         elseif( isset( $gatewayData["approveRequest"])){
+            $gateway->emailAddress = $gatewayData["emailAddress"];
+            $gateway->gatewayURL = $gatewayData["gatewayURL"];
+            $gateway->gatewayAdminFirstName = $gatewayData["gatewayAdminFirstName"];
+            $gateway->gatewayAdminLastName = $gatewayData["gatewayAdminLastName"];
+            $gateway->identityServerUserName = $gatewayData["identityServerUserName"];
+            $gateway->reviewProposalDescription = $gatewayData["reviewProposalDescription"];
+            $gateway->gatewayPublicAbstract = $gatewayData["gatewayPublicAbstract"];
             $gateway->gatewayApprovalStatus = GatewayApprovalStatus::APPROVED;
         }
         elseif( isset( $gatewayData["denyRequest"])){


### PR DESCRIPTION
The Admin can update Gateway details before approving the Gateway request. These newly set information will now be visible to Gateway Providers and Admins to edit.