### PR TITLE
[AIRAVATA-2521] Ability define gateway level maximum values for walltime, node and CPU counts

### DIFF
--- a/app/config/pga_config.php.template
+++ b/app/config/pga_config.php.template
@@ -180,6 +180,21 @@ return array(
         'wall-time-limit' => '30',
 
         /**
+         * Max node count
+         */
+        'max-node-count' => '4',
+
+        /**
+         * Max total core count
+         */
+        'max-total-cpu-count' => '96',
+
+        /**
+         * Max wall time limit
+         */
+        'max-wall-time-limit' => '120',
+
+        /**
          * Enable app-catalog cache
          */
         'enable-app-catalog-cache' => true,

--- a/app/libraries/ExperimentUtilities.php
+++ b/app/libraries/ExperimentUtilities.php
@@ -1422,7 +1422,25 @@ class ExperimentUtilities
     public static function getQueueDatafromResourceId($crId)
     {
         $resourceObject = Airavata::getComputeResource(Session::get('authz-token'), $crId);
-        return $resourceObject->batchQueues;
+        $queues =  $resourceObject->batchQueues;
+
+        //Defining maximum allowed value for queue resources
+        $maxNodeCount = Config::get('pga_config.airavata')["max-node-count"];
+        $maxCPUCount = Config::get('pga_config.airavata')["max-total-cpu-count"];
+        $maxWallTimeLimit = Config::get('pga_config.airavata')["max-wall-time-limit"];
+
+        foreach($queues as $aQueue){
+            if($aQueue->maxNodes > $maxNodeCount){
+                $aQueue->maxNodes = $maxNodeCount;
+            }
+            if($aQueue->maxProcessors > $maxCPUCount){
+                $aQueue->maxProcessors = $maxCPUCount;
+            }
+            if($aQueue->maxRunTime > $maxWallTimeLimit){
+                $aQueue->maxRunTime = $maxWallTimeLimit;
+            }
+        }
+        return $queues;
     }
 
     /**


### PR DESCRIPTION
- Added the maximum allowed values for the nodes, CPU cores and wall time limit to the pga_config.php.template for reference.
- Modified the createSubmit() and editSubmit() methods in ExperiementController.php to validate the entered values for nodes, CPU cores and wall time limit for a given experiment. If invalid, an appropriate message is returned to the view.
- Added a new private method - validateQueueData() in ExperiementController.php to perform the validation of the queue values.
- Modified the getQueueDatafromResourceId() method in ExperiementUtilities.php to compare the queue's maximum values for nodes, CPU cores and wall time limit with that of the gateway's configuration (found in the pga_config.php file)