### PR TITLE
[AIRAVATA-2531] Change PGA + registry to show Job details

### DIFF
--- a/app/libraries/AdminUtilities.php
+++ b/app/libraries/AdminUtilities.php
@@ -4,6 +4,7 @@ use Airavata\Model\Workspace\Gateway;
 use Airavata\Model\Workspace\GatewayApprovalStatus;
 use Airavata\Model\Workspace\Notification;
 use Airavata\Model\Workspace\NotificationPriority;
+use Airavata\Model\Status\JobState;
 use Airavata\Model\Credential\Store\CredentialOwnerType;
 use Illuminate\Support\Facades\Log;
 
@@ -300,7 +301,19 @@ class AdminUtilities
         foreach ($experiments as $experiment) {
             //var_dump( $experiment); exit;
             $expValue = ExperimentUtilities::get_experiment_values($experiment, true);
+            $jobDetails = ExperimentUtilities::get_job_details($experiment->experimentId);
+            foreach( $jobDetails as $index => $jobDetail){
+                if(isset($jobDetail->jobStatuses)){
+                      $jobDetails[ $index]->jobStatuses[0]->jobStateName = JobState::$__names[$jobDetail->jobStatuses[0]->jobState];
+                }
+                else{
+                    $jobDetails[ $index]->jobStatuses = [new stdClass()];
+                    $jobDetails[ $index]->jobStatuses[0]->jobStateName = null;
+                }
+            }
+
             $expContainer[$expNum]['experiment'] = $experiment;
+            $expContainer[$expNum]['jobDetails'] = $jobDetails;
             $expValue["editable"] = false;
             $expContainer[$expNum]['expValue'] = $expValue;
             $expNum++;

--- a/app/libraries/ExperimentUtilities.php
+++ b/app/libraries/ExperimentUtilities.php
@@ -1242,18 +1242,7 @@ class ExperimentUtilities
         foreach ($experiments as $experiment) {
             if(Config::get('pga_config.airavata')["data-sharing-enabled"]){
                 if (SharingUtilities::userCanRead(Session::get('username'), $experiment->experimentId, ResourceType::EXPERIMENT)) {
-                    $expValue = ExperimentUtilities::get_experiment_values($experiment, true);
-                    $jobDetails = ExperimentUtilities::get_job_details($experiment->experimentId);
-
-                    foreach( $jobDetails as $index => $jobDetail){
-                        if(isset($jobDetail->jobStatuses)){
-                            $jobDetails[ $index]->jobStatuses[0]->jobStateName = JobState::$__names[$jobDetail->jobStatuses[0]->jobState];
-                        }else {
-                            $jobDetails[ $index]->jobStatuses = [new stdClass()];
-                            $jobDetails[ $index]->jobStatuses[0]->jobStateName = null;
-                        }
-                    }
-                    $expValue["jobDetails"] = $jobDetails
+                    $expValue = ExperimentUtilities::get_experiment_values($experiment, true);                 
                     $expContainer[$expNum]['experiment'] = $experiment;
                     if ($expValue["experimentStatusString"] == "FAILED")
                         $expValue["editable"] = false;
@@ -1262,17 +1251,6 @@ class ExperimentUtilities
                 }
             }else {
                 $expValue = ExperimentUtilities::get_experiment_values($experiment, true);
-                $jobDetails = ExperimentUtilities::get_job_details($experiment->experimentId);
-
-                    foreach( $jobDetails as $index => $jobDetail){
-                        if(isset($jobDetail->jobStatuses)){
-                            $jobDetails[ $index]->jobStatuses[0]->jobStateName = JobState::$__names[$jobDetail->jobStatuses[0]->jobState];
-                        }else {
-                            $jobDetails[ $index]->jobStatuses = [new stdClass()];
-                            $jobDetails[ $index]->jobStatuses[0]->jobStateName = null;
-                        }
-                    }
-                $expValue["jobDetails"] = $jobDetails
                 $expContainer[$expNum]['experiment'] = $experiment;
                 if ($expValue["experimentStatusString"] == "FAILED")
                     $expValue["editable"] = false;

--- a/app/libraries/ExperimentUtilities.php
+++ b/app/libraries/ExperimentUtilities.php
@@ -691,7 +691,7 @@ class ExperimentUtilities
             if ($experiment->userConfigurationData->useUserCRPref){
                 // Check if this user has a user CR preference for the compute
                 // resource, if not we want to switch this flag to false
-                $userComputeResourcePreferences = URPUtilities::get_all_validated_user_compute_resource_prefs();
+                $userComputeResourcePreferences = URPUtilities::get_all_user_compute_resource_prefs();
                 $userHasComputeResourcePreference = array_key_exists($computeResourceId, $userComputeResourcePreferences);
                 $experiment->userConfigurationData->useUserCRPref = $userHasComputeResourcePreference;
             }
@@ -1243,14 +1243,36 @@ class ExperimentUtilities
             if(Config::get('pga_config.airavata')["data-sharing-enabled"]){
                 if (SharingUtilities::userCanRead(Session::get('username'), $experiment->experimentId, ResourceType::EXPERIMENT)) {
                     $expValue = ExperimentUtilities::get_experiment_values($experiment, true);
+                    $jobDetails = ExperimentUtilities::get_job_details($experiment->experimentId);
+
+                    foreach( $jobDetails as $index => $jobDetail){
+                        if(isset($jobDetail->jobStatuses)){
+                            $jobDetails[ $index]->jobStatuses[0]->jobStateName = JobState::$__names[$jobDetail->jobStatuses[0]->jobState];
+                        }else {
+                            $jobDetails[ $index]->jobStatuses = [new stdClass()];
+                            $jobDetails[ $index]->jobStatuses[0]->jobStateName = null;
+                        }
+                    }
+                    $expValue["jobDetails"] = $jobDetails
                     $expContainer[$expNum]['experiment'] = $experiment;
                     if ($expValue["experimentStatusString"] == "FAILED")
                         $expValue["editable"] = false;
                     $expContainer[$expNum]['expValue'] = $expValue;
                     $expNum++;
                 }
-            }else{
+            }else {
                 $expValue = ExperimentUtilities::get_experiment_values($experiment, true);
+                $jobDetails = ExperimentUtilities::get_job_details($experiment->experimentId);
+
+                    foreach( $jobDetails as $index => $jobDetail){
+                        if(isset($jobDetail->jobStatuses)){
+                            $jobDetails[ $index]->jobStatuses[0]->jobStateName = JobState::$__names[$jobDetail->jobStatuses[0]->jobState];
+                        }else {
+                            $jobDetails[ $index]->jobStatuses = [new stdClass()];
+                            $jobDetails[ $index]->jobStatuses[0]->jobStateName = null;
+                        }
+                    }
+                $expValue["jobDetails"] = $jobDetails
                 $expContainer[$expNum]['experiment'] = $experiment;
                 if ($expValue["experimentStatusString"] == "FAILED")
                     $expValue["editable"] = false;

--- a/app/libraries/ExperimentUtilities.php
+++ b/app/libraries/ExperimentUtilities.php
@@ -1242,14 +1242,14 @@ class ExperimentUtilities
         foreach ($experiments as $experiment) {
             if(Config::get('pga_config.airavata')["data-sharing-enabled"]){
                 if (SharingUtilities::userCanRead(Session::get('username'), $experiment->experimentId, ResourceType::EXPERIMENT)) {
-                    $expValue = ExperimentUtilities::get_experiment_values($experiment, true);                 
+                    $expValue = ExperimentUtilities::get_experiment_values($experiment, true);
                     $expContainer[$expNum]['experiment'] = $experiment;
                     if ($expValue["experimentStatusString"] == "FAILED")
                         $expValue["editable"] = false;
                     $expContainer[$expNum]['expValue'] = $expValue;
                     $expNum++;
                 }
-            }else {
+            }else{
                 $expValue = ExperimentUtilities::get_experiment_values($experiment, true);
                 $expContainer[$expNum]['experiment'] = $experiment;
                 if ($expValue["experimentStatusString"] == "FAILED")

--- a/app/libraries/ExperimentUtilities.php
+++ b/app/libraries/ExperimentUtilities.php
@@ -691,7 +691,7 @@ class ExperimentUtilities
             if ($experiment->userConfigurationData->useUserCRPref){
                 // Check if this user has a user CR preference for the compute
                 // resource, if not we want to switch this flag to false
-                $userComputeResourcePreferences = URPUtilities::get_all_user_compute_resource_prefs();
+                $userComputeResourcePreferences = URPUtilities::get_all_validated_user_compute_resource_prefs();
                 $userHasComputeResourcePreference = array_key_exists($computeResourceId, $userComputeResourcePreferences);
                 $experiment->userConfigurationData->useUserCRPref = $userHasComputeResourcePreference;
             }


### PR DESCRIPTION
Made changes to include job details in the experiment container that was being returned from `AdminUtilities::get_experiments_of_time_range()` function.

Now the job details can be accessed in the `experiment-container.blade.php` file and **Job Status** can be displayed as shown below.

<img width="836" alt="changes" src="https://user-images.githubusercontent.com/7189607/31059371-f52ddc2e-a6ce-11e7-9167-065896d7e6cf.PNG">


