### PR TITLE
[AIRAVATA-2509] Account confirmation, password reset emails not making it to user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ pga_config.php
 
 /app/storage
 /themes
+
+.iws
+workspace.xml
+tasks.xml

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ pga_config.php
 /app/storage
 /themes
 
+.idea
 .iws
 workspace.xml
 tasks.xml

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ composer.lock
 .env.php
 .DS_Store
 Thumbs.db
+pga_config.php
 
 /app/storage
 /themes

--- a/app/controllers/AccountController.php
+++ b/app/controllers/AccountController.php
@@ -53,7 +53,7 @@ class AccountController extends BaseController
 
         if (Keycloak::usernameExists($username)) {
             return Redirect::to("create")
-                ->withInput(Input::except('password', 'confirm_password', 'email', 'confirm_email'))
+                ->withInput(Input::except('password', 'confirm_password'))
                 ->with("username_exists", true);
         } else {
 

--- a/app/controllers/AccountController.php
+++ b/app/controllers/AccountController.php
@@ -30,6 +30,7 @@ class AccountController extends BaseController
             "password" => self::PASSWORD_VALIDATION,
             "confirm_password" => "required|same:password",
             "email" => "required|email",
+            "confirm_email" => "required|same:email",
         );
 
         $messages = array(
@@ -40,7 +41,7 @@ class AccountController extends BaseController
         $validator = Validator::make(Input::all(), $rules, $messages);
         if ($validator->fails()) {
             return Redirect::to("create")
-                ->withInput(Input::except('password', 'password_confirm'))
+                ->withInput(Input::except('password', 'confirm_password', 'email', 'confirm_email'))
                 ->withErrors($validator);
         }
 
@@ -52,7 +53,7 @@ class AccountController extends BaseController
 
         if (Keycloak::usernameExists($username)) {
             return Redirect::to("create")
-                ->withInput(Input::except('password', 'password_confirm'))
+                ->withInput(Input::except('password', 'confirm_password', 'email', 'confirm_email'))
                 ->with("username_exists", true);
         } else {
 

--- a/app/libraries/EmailUtilities.php
+++ b/app/libraries/EmailUtilities.php
@@ -19,7 +19,11 @@ class EmailUtilities
         $body = str_replace("\$lastName", $lastName, $body);
         $body = str_replace("\$validTime", $validTime, $body);
 
-        EmailUtilities::sendEmail($subject, [$email], $body);
+        $recipient['firstName'] = $firstName;
+        $recipient['lastName'] = $lastName;
+        $recipient['email'] = $email;
+
+        EmailUtilities::sendEmail($subject, [$recipient], $body);
     }
 
     public static function verifyEmailVerification($username, $code){
@@ -47,7 +51,11 @@ class EmailUtilities
         $body = str_replace("\$lastName", $lastName, $body);
         $body = str_replace("\$validTime", $validTime, $body);
 
-        EmailUtilities::sendEmail($subject, [$email], $body);
+        $recipient['firstName'] = $firstName;
+        $recipient['lastName'] = $lastName;
+        $recipient['email'] = $email;
+
+        EmailUtilities::sendEmail($subject, [$recipient], $body);
     }
 
     public static function verifyUpdatedEmailAccount($username, $code){
@@ -76,7 +84,11 @@ class EmailUtilities
         $body = str_replace("\$lastName", $lastName, $body);
         $body = str_replace("\$validTime", $validTime, $body);
 
-        EmailUtilities::sendEmail($subject, [$email], $body);
+        $recipient['firstName'] = $firstName;
+        $recipient['lastName'] = $lastName;
+        $recipient['email'] = $email;
+
+        EmailUtilities::sendEmail($subject, [$recipient], $body);
     }
 
     public static function verifyPasswordResetCode($username, $code){
@@ -90,7 +102,7 @@ class EmailUtilities
     }
 
     //PGA sends email to Admin about new request
-    public static function gatewayRequestMail($firstName, $lastName, $email, $gatewayName){
+    public static function gatewayRequestMail($firstName, $lastName, $emails, $gatewayName){
 
         $emailTemplates = json_decode(File::get(app_path() . '/config/email_templates.json'));
         $subject = $emailTemplates->gateway_request->subject;
@@ -101,7 +113,13 @@ class EmailUtilities
         $body = str_replace("\$lastName", $lastName, $body);
         $body = str_replace("\$gatewayName", $gatewayName, $body);
 
-        EmailUtilities::sendEmail($subject, $email, $body);
+        $recipients = array();
+        foreach($emails as $email) {
+            $recipient['email'] = $email;
+            array_push($recipients, $recipient);
+        }
+
+        EmailUtilities::sendEmail($subject, $recipients, $body);
 
     }
 
@@ -115,13 +133,14 @@ class EmailUtilities
         $body = str_replace("\$url", URL::to('/') . '/admin/dashboard', $body);
         $body = str_replace("\$gatewayId", $gatewayId, $body);
 
+        $recipient['email'] = $email;
 
-        EmailUtilities::sendEmail($subject, [$email], $body);
+        EmailUtilities::sendEmail($subject, [$recipient], $body);
 
     }
 
     //PGA sends email to Admin when Gateway is UPDATED
-    public static function gatewayUpdateMailToAdmin($email, $gatewayId){
+    public static function gatewayUpdateMailToAdmin($emails, $gatewayId){
 
         $emailTemplates = json_decode(File::get(app_path() . '/config/email_templates.json'));
         $subject = $emailTemplates->update_to_admin->subject;
@@ -130,7 +149,13 @@ class EmailUtilities
         $body = str_replace("\$url", URL::to('/') . '/admin/dashboard/gateway', $body);
         $body = str_replace("\$gatewayId", $gatewayId, $body);
 
-        EmailUtilities::sendEmail($subject, $email, $body);
+        $recipients = array();
+        foreach($emails as $email) {
+            $recipient['email'] = $email;
+            array_push($recipients, $recipient);
+        }
+
+        EmailUtilities::sendEmail($subject, $recipients, $body);
 
     }
 
@@ -159,7 +184,12 @@ class EmailUtilities
         $mail->ContentType = 'text/html; charset=utf-8\r\n';
 
         foreach($recipients as $recipient){
-            $mail->addAddress($recipient);
+            if (array_key_exists('firstName', $recipient) && array_key_exists('lastName', $recipient)) {
+                $mail->addAddress($recipient['email'], $recipient['firstName'] . " " . $recipient['lastName']);
+            }
+            else {
+                $mail->addAddress($recipient['email']);
+            }
         }
 
         $mail->Subject = $subject;

--- a/app/libraries/EmailUtilities.php
+++ b/app/libraries/EmailUtilities.php
@@ -19,6 +19,7 @@ class EmailUtilities
         $body = str_replace("\$lastName", $lastName, $body);
         $body = str_replace("\$validTime", $validTime, $body);
 
+        $recipient = array();
         $recipient['firstName'] = $firstName;
         $recipient['lastName'] = $lastName;
         $recipient['email'] = $email;
@@ -51,6 +52,7 @@ class EmailUtilities
         $body = str_replace("\$lastName", $lastName, $body);
         $body = str_replace("\$validTime", $validTime, $body);
 
+        $recipient = array();
         $recipient['firstName'] = $firstName;
         $recipient['lastName'] = $lastName;
         $recipient['email'] = $email;
@@ -84,6 +86,7 @@ class EmailUtilities
         $body = str_replace("\$lastName", $lastName, $body);
         $body = str_replace("\$validTime", $validTime, $body);
 
+        $recipient = array();
         $recipient['firstName'] = $firstName;
         $recipient['lastName'] = $lastName;
         $recipient['email'] = $email;
@@ -133,6 +136,7 @@ class EmailUtilities
         $body = str_replace("\$url", URL::to('/') . '/admin/dashboard', $body);
         $body = str_replace("\$gatewayId", $gatewayId, $body);
 
+        $recipient = array();
         $recipient['email'] = $email;
 
         EmailUtilities::sendEmail($subject, [$recipient], $body);

--- a/app/views/account/create.blade.php
+++ b/app/views/account/create.blade.php
@@ -72,8 +72,14 @@
 
             <div><input class="form-control" id="email" name="email" placeholder="email@example.com"
                         required="required" title="" type="email" value="{{Input::old('email') }}"
-                         data-toggle="popover" data-placement="left" data-content="Please make sure that you enter a correct email address as a verification mail will be sent to this addresss."/></div>
+                         data-toggle="popover" data-placement="left" data-content="Please make sure that you enter a correct email address as a verification mail will be sent to this address."/></div>
         </div>
+        <div class="form-group required"><label class="control-label">E-mail (again)</label>
+
+                <div><input class="form-control" id="confirm_email" name="confirm_email" placeholder="email@example.com (again)"
+                            required="required" title="" type="email" value="{{Input::old('confirm_email') }}"
+                            data-toggle="popover" data-placement="left" data-content="Please make sure that you enter the same email address as above as a verification mail will be sent to this address."/></div>
+            </div>
         <div class="form-group required"><label class="control-label">First Name</label>
 
             <div><input class="form-control" id="first_name" maxlength="30" name="first_name"


### PR DESCRIPTION
1. Now we use the recipient's full name (first name and last name) along with their email address to send the email. This reduces the likelihood of the mail being marked as spam.
<img width="1066" alt="screen shot 2017-11-16 at 17 58 27" src="https://user-images.githubusercontent.com/16287470/32920670-2ecd2668-caf8-11e7-9102-f412b4aeb04e.png">

2. Added another field 'E-mail (again)' to 'Create New Test Drive Account' page to make sure the user does not make a typo in the email address. Added code to make sure 'E-mail' and 'E-mail (again)' fields match. If there is a problem with the data validation, the user has to re-enter the 'E-mail' and 'E-mail (again)' fields along with 'Password' and 'Password (again)' fields.
<img width="1280" alt="screen shot 2017-11-16 at 17 57 40" src="https://user-images.githubusercontent.com/16287470/32920762-9379c2e2-caf8-11e7-829c-167b038d1806.png">

